### PR TITLE
Use GitHubAccount value objects instead of GitHubUser value objects where applicable

### DIFF
--- a/spec/GitHubRepoSpec.php
+++ b/spec/GitHubRepoSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Devboard\GitHub;
 
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\GitHubRepo;
 use Devboard\GitHub\Repo\GitHubRepoEndpoints;
 use Devboard\GitHub\Repo\GitHubRepoFullName;
@@ -12,7 +13,6 @@ use Devboard\GitHub\Repo\GitHubRepoName;
 use Devboard\GitHub\Repo\GitHubRepoOwner;
 use Devboard\GitHub\Repo\GitHubRepoStats;
 use Devboard\GitHub\Repo\GitHubRepoTimestamps;
-use Devboard\GitHub\User\GitHubUserLogin;
 use PhpSpec\ObjectBehavior;
 
 class GitHubRepoSpec extends ObjectBehavior
@@ -61,7 +61,7 @@ class GitHubRepoSpec extends ObjectBehavior
 
     public function it_exposes_parts_of_full_name(
         GitHubRepoFullName $fullName,
-        GitHubUserLogin $userLogin,
+        GitHubAccountLogin $userLogin,
         GitHubRepoName $repoName
     ) {
         $fullName->getOwner()->shouldBeCalled()->willReturn($userLogin);

--- a/spec/Repo/GitHubRepoFullNameSpec.php
+++ b/spec/Repo/GitHubRepoFullNameSpec.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace spec\Devboard\GitHub\Repo;
 
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Repo\GitHubRepoFullName;
 use Devboard\GitHub\Repo\GitHubRepoName;
-use Devboard\GitHub\User\GitHubUserLogin;
 use PhpSpec\ObjectBehavior;
 
 class GitHubRepoFullNameSpec extends ObjectBehavior
 {
-    public function let(GitHubUserLogin $owner, GitHubRepoName $repoName)
+    public function let(GitHubAccountLogin $owner, GitHubRepoName $repoName)
     {
         $owner->getValue()->willReturn('devboard-test');
         $repoName->getValue()->willReturn('super-library');
@@ -29,7 +29,7 @@ class GitHubRepoFullNameSpec extends ObjectBehavior
         $this->createFromString('devboard-test/super-library')->shouldReturnAnInstanceOf(GitHubRepoFullName::class);
     }
 
-    public function it_should_expose_owner_as_object(GitHubUserLogin $owner)
+    public function it_should_expose_owner_as_object(GitHubAccountLogin $owner)
     {
         $this->getOwner()->shouldReturn($owner);
     }

--- a/spec/Repo/GitHubRepoOwnerSpec.php
+++ b/spec/Repo/GitHubRepoOwnerSpec.php
@@ -4,26 +4,26 @@ declare(strict_types=1);
 
 namespace spec\Devboard\GitHub\Repo;
 
+use Devboard\GitHub\Account\GitHubAccountApiUrl;
+use Devboard\GitHub\Account\GitHubAccountAvatarUrl;
+use Devboard\GitHub\Account\GitHubAccountGravatarId;
+use Devboard\GitHub\Account\GitHubAccountHtmlUrl;
+use Devboard\GitHub\Account\GitHubAccountId;
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Account\GitHubAccountType;
 use Devboard\GitHub\Repo\GitHubRepoOwner;
-use Devboard\GitHub\User\GitHubUserApiUrl;
-use Devboard\GitHub\User\GitHubUserAvatarUrl;
-use Devboard\GitHub\User\GitHubUserGravatarId;
-use Devboard\GitHub\User\GitHubUserHtmlUrl;
-use Devboard\GitHub\User\GitHubUserId;
-use Devboard\GitHub\User\GitHubUserLogin;
 use PhpSpec\ObjectBehavior;
 
 class GitHubRepoOwnerSpec extends ObjectBehavior
 {
     public function let(
-        GitHubUserId $userId,
-        GitHubUserLogin $login,
+        GitHubAccountId $userId,
+        GitHubAccountLogin $login,
         GitHubAccountType $gitHubAccountType,
-        GitHubUserAvatarUrl $avatarUrl,
-        GitHubUserGravatarId $gravatarId,
-        GitHubUserHtmlUrl $htmlUrl,
-        GitHubUserApiUrl $apiUrl
+        GitHubAccountAvatarUrl $avatarUrl,
+        GitHubAccountGravatarId $gravatarId,
+        GitHubAccountHtmlUrl $htmlUrl,
+        GitHubAccountApiUrl $apiUrl
     ) {
         $this->beConstructedWith(
             $userId,
@@ -43,13 +43,13 @@ class GitHubRepoOwnerSpec extends ObjectBehavior
     }
 
     public function it_should_expose_all_values_via_getters(
-        GitHubUserId $userId,
-        GitHubUserLogin $login,
+        GitHubAccountId $userId,
+        GitHubAccountLogin $login,
         GitHubAccountType $gitHubAccountType,
-        GitHubUserAvatarUrl $avatarUrl,
-        GitHubUserGravatarId $gravatarId,
-        GitHubUserHtmlUrl $htmlUrl,
-        GitHubUserApiUrl $apiUrl
+        GitHubAccountAvatarUrl $avatarUrl,
+        GitHubAccountGravatarId $gravatarId,
+        GitHubAccountHtmlUrl $htmlUrl,
+        GitHubAccountApiUrl $apiUrl
     ) {
         $this->getUserId()->shouldReturn($userId);
         $this->getLogin()->shouldReturn($login);

--- a/src/GitHubRepo.php
+++ b/src/GitHubRepo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Devboard\GitHub;
 
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Repo\GitHubRepoEndpoints;
 use Devboard\GitHub\Repo\GitHubRepoFullName;
 use Devboard\GitHub\Repo\GitHubRepoId;
@@ -11,7 +12,6 @@ use Devboard\GitHub\Repo\GitHubRepoName;
 use Devboard\GitHub\Repo\GitHubRepoOwner;
 use Devboard\GitHub\Repo\GitHubRepoStats;
 use Devboard\GitHub\Repo\GitHubRepoTimestamps;
-use Devboard\GitHub\User\GitHubUserLogin;
 
 /**
  * @see GitHubRepoSpec
@@ -62,7 +62,7 @@ class GitHubRepo
         return $this->fullName;
     }
 
-    public function getOwnerLogin(): GitHubUserLogin
+    public function getOwnerLogin(): GitHubAccountLogin
     {
         return $this->fullName->getOwner();
     }

--- a/src/Repo/GitHubRepoFullName.php
+++ b/src/Repo/GitHubRepoFullName.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Devboard\GitHub\Repo;
 
-use Devboard\GitHub\User\GitHubUserLogin;
+use Devboard\GitHub\Account\GitHubAccountLogin;
 
 /**
  * @see GitHubRepoFullNameSpec
@@ -12,12 +12,12 @@ use Devboard\GitHub\User\GitHubUserLogin;
  */
 class GitHubRepoFullName
 {
-    /** @var GitHubUserLogin */
+    /** @var GitHubAccountLogin */
     private $owner;
     /** @var \Devboard\GitHub\Repo\GitHubRepoName */
     private $repoName;
 
-    public function __construct(GitHubUserLogin $owner, GitHubRepoName $repoName)
+    public function __construct(GitHubAccountLogin $owner, GitHubRepoName $repoName)
     {
         $this->owner    = $owner;
         $this->repoName = $repoName;
@@ -27,7 +27,7 @@ class GitHubRepoFullName
     {
         list($owner, $name) = explode('/', $fullName);
 
-        return new self(new GitHubUserLogin($owner), new GitHubRepoName($name));
+        return new self(new GitHubAccountLogin($owner), new GitHubRepoName($name));
     }
 
     public function getValue(): string
@@ -40,7 +40,7 @@ class GitHubRepoFullName
         return $this->getValue();
     }
 
-    public function getOwner(): GitHubUserLogin
+    public function getOwner(): GitHubAccountLogin
     {
         return $this->owner;
     }

--- a/src/Repo/GitHubRepoOwner.php
+++ b/src/Repo/GitHubRepoOwner.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Devboard\GitHub\Repo;
 
+use Devboard\GitHub\Account\GitHubAccountApiUrl;
+use Devboard\GitHub\Account\GitHubAccountAvatarUrl;
+use Devboard\GitHub\Account\GitHubAccountGravatarId;
+use Devboard\GitHub\Account\GitHubAccountHtmlUrl;
+use Devboard\GitHub\Account\GitHubAccountId;
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Account\GitHubAccountType;
 use Devboard\GitHub\Account\GitHubAccountTypeFactory;
-use Devboard\GitHub\User\GitHubUserApiUrl;
-use Devboard\GitHub\User\GitHubUserAvatarUrl;
-use Devboard\GitHub\User\GitHubUserGravatarId;
-use Devboard\GitHub\User\GitHubUserHtmlUrl;
-use Devboard\GitHub\User\GitHubUserId;
-use Devboard\GitHub\User\GitHubUserLogin;
 
 /**
  * @see GitHubRepoOwnerSpec
@@ -19,31 +19,31 @@ use Devboard\GitHub\User\GitHubUserLogin;
  */
 class GitHubRepoOwner
 {
-    /** @var GitHubUserId */
+    /** @var GitHubAccountId */
     private $userId;
-    /** @var GitHubUserLogin */
+    /** @var GitHubAccountLogin */
     private $login;
     /** @var GitHubAccountType */
     private $gitHubAccountType;
-    /** @var GitHubUserAvatarUrl */
+    /** @var GitHubAccountAvatarUrl */
     private $avatarUrl;
-    /** @var GitHubUserGravatarId */
+    /** @var GitHubAccountGravatarId */
     private $gravatarId;
-    /** @var GitHubUserHtmlUrl */
+    /** @var GitHubAccountHtmlUrl */
     private $htmlUrl;
-    /** @var GitHubUserApiUrl */
+    /** @var GitHubAccountApiUrl */
     private $apiUrl;
     /** @var bool */
     private $siteAdmin;
 
     public function __construct(
-        GitHubUserId $userId,
-        GitHubUserLogin $login,
+        GitHubAccountId $userId,
+        GitHubAccountLogin $login,
         GitHubAccountType $gitHubAccountType,
-        GitHubUserAvatarUrl $avatarUrl,
-        GitHubUserGravatarId $gravatarId,
-        GitHubUserHtmlUrl $htmlUrl,
-        GitHubUserApiUrl $apiUrl,
+        GitHubAccountAvatarUrl $avatarUrl,
+        GitHubAccountGravatarId $gravatarId,
+        GitHubAccountHtmlUrl $htmlUrl,
+        GitHubAccountApiUrl $apiUrl,
         bool $siteAdmin
     ) {
         $this->userId            = $userId;
@@ -56,12 +56,12 @@ class GitHubRepoOwner
         $this->siteAdmin         = $siteAdmin;
     }
 
-    public function getUserId(): GitHubUserId
+    public function getUserId(): GitHubAccountId
     {
         return $this->userId;
     }
 
-    public function getLogin(): GitHubUserLogin
+    public function getLogin(): GitHubAccountLogin
     {
         return $this->login;
     }
@@ -71,22 +71,22 @@ class GitHubRepoOwner
         return $this->gitHubAccountType;
     }
 
-    public function getAvatarUrl(): GitHubUserAvatarUrl
+    public function getAvatarUrl(): GitHubAccountAvatarUrl
     {
         return $this->avatarUrl;
     }
 
-    public function getGravatarId(): GitHubUserGravatarId
+    public function getGravatarId(): GitHubAccountGravatarId
     {
         return $this->gravatarId;
     }
 
-    public function getHtmlUrl(): GitHubUserHtmlUrl
+    public function getHtmlUrl(): GitHubAccountHtmlUrl
     {
         return $this->htmlUrl;
     }
 
-    public function getApiUrl(): GitHubUserApiUrl
+    public function getApiUrl(): GitHubAccountApiUrl
     {
         return $this->apiUrl;
     }
@@ -113,13 +113,13 @@ class GitHubRepoOwner
     public static function deserialize(array $data): GitHubRepoOwner
     {
         return new self(
-            new GitHubUserId($data['userId']),
-            new GitHubUserLogin($data['login']),
+            new GitHubAccountId($data['userId']),
+            new GitHubAccountLogin($data['login']),
             GitHubAccountTypeFactory::create($data['GitHubAccountType']),
-            new GitHubUserAvatarUrl($data['avatarUrl']),
-            new GitHubUserGravatarId($data['gravatarId']),
-            new GitHubUserHtmlUrl($data['htmlUrl']),
-            new GitHubUserApiUrl($data['apiUrl']),
+            new GitHubAccountAvatarUrl($data['avatarUrl']),
+            new GitHubAccountGravatarId($data['gravatarId']),
+            new GitHubAccountHtmlUrl($data['htmlUrl']),
+            new GitHubAccountApiUrl($data['apiUrl']),
             $data['siteAdmin']
         );
     }

--- a/tests/GitHubBranchTest.php
+++ b/tests/GitHubBranchTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests\Devboard\GitHub;
 
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Account\Type\User;
 use Devboard\GitHub\Branch\GitHubBranchName as BranchName;
 use Devboard\GitHub\Commit\Author\GitHubCommitAuthorEmail;
@@ -65,7 +66,7 @@ class GitHubBranchTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 new RepoFullName(
-                    new GitHubUserLogin('devboard-test'), new GitHubRepoName('super-library')
+                    new GitHubAccountLogin('devboard-test'), new GitHubRepoName('super-library')
                 ),
                 new BranchName('master'),
                 new GitHubCommit(

--- a/tests/GitHubRepoTest.php
+++ b/tests/GitHubRepoTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace tests\Devboard\GitHub;
 
+use Devboard\GitHub\Account\GitHubAccountApiUrl;
+use Devboard\GitHub\Account\GitHubAccountAvatarUrl;
+use Devboard\GitHub\Account\GitHubAccountGravatarId;
+use Devboard\GitHub\Account\GitHubAccountHtmlUrl;
+use Devboard\GitHub\Account\GitHubAccountId;
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Account\Type\User;
 use Devboard\GitHub\GitHubRepo;
 use Devboard\GitHub\Repo\GitHubRepoApiUrl;
@@ -19,12 +25,6 @@ use Devboard\GitHub\Repo\GitHubRepoSize;
 use Devboard\GitHub\Repo\GitHubRepoStats;
 use Devboard\GitHub\Repo\GitHubRepoTimestamps;
 use Devboard\GitHub\Repo\GitHubRepoUpdatedAt;
-use Devboard\GitHub\User\GitHubUserApiUrl;
-use Devboard\GitHub\User\GitHubUserAvatarUrl;
-use Devboard\GitHub\User\GitHubUserGravatarId;
-use Devboard\GitHub\User\GitHubUserHtmlUrl;
-use Devboard\GitHub\User\GitHubUserId;
-use Devboard\GitHub\User\GitHubUserLogin;
 
 /**
  * @covers \Devboard\GitHub\GitHubRepo
@@ -79,16 +79,16 @@ class GitHubRepoTest extends \PHPUnit_Framework_TestCase
             [
                 new GitHubRepoId(1234),
                 new GitHubRepoFullName(
-                    new GitHubUserLogin('devboard-test'), new GitHubRepoName('super-library')
+                    new GitHubAccountLogin('devboard-test'), new GitHubRepoName('super-library')
                 ),
                 new GitHubRepoOwner(
-                    new GitHubUserId(789),
-                    new GitHubUserLogin('devboard-test'),
+                    new GitHubAccountId(789),
+                    new GitHubAccountLogin('devboard-test'),
                     new User(),
-                    new GitHubUserAvatarUrl('..'),
-                    new GitHubUserGravatarId('..'),
-                    new GitHubUserHtmlUrl('..'),
-                    new GitHubUserApiUrl('..'),
+                    new GitHubAccountAvatarUrl('..'),
+                    new GitHubAccountGravatarId('..'),
+                    new GitHubAccountHtmlUrl('..'),
+                    new GitHubAccountApiUrl('..'),
                     false
                 ),
                 false,
@@ -106,7 +106,7 @@ class GitHubRepoTest extends \PHPUnit_Framework_TestCase
             [
                 new GitHubRepoId(1234),
                 new GitHubRepoFullName(
-                    new GitHubUserLogin('devboard-test'), new GitHubRepoName('super-library')
+                    new GitHubAccountLogin('devboard-test'), new GitHubRepoName('super-library')
                 ),
                 null,
                 false,

--- a/tests/GitHubTagTest.php
+++ b/tests/GitHubTagTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace tests\Devboard\GitHub;
 
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Account\Type\User;
 use Devboard\GitHub\Commit\Author\GitHubCommitAuthorEmail;
 use Devboard\GitHub\Commit\Author\GitHubCommitAuthorName;
@@ -65,7 +66,7 @@ class GitHubTagTest extends \PHPUnit_Framework_TestCase
         return [
             [
                 new RepoFullName(
-                    new GitHubUserLogin('devboard-test'), new GitHubRepoName('super-library')
+                    new GitHubAccountLogin('devboard-test'), new GitHubRepoName('super-library')
                 ),
                 new TagName('master'),
                 new GitHubCommit(

--- a/tests/Repo/GitHubRepoFullNameTest.php
+++ b/tests/Repo/GitHubRepoFullNameTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace tests\Devboard\GitHub\Repo;
 
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Repo\GitHubRepoFullName;
 use Devboard\GitHub\Repo\GitHubRepoName;
-use Devboard\GitHub\User\GitHubUserLogin;
 
 /**
  * @covers \Devboard\GitHub\Repo\GitHubRepoFullName
@@ -15,35 +15,35 @@ use Devboard\GitHub\User\GitHubUserLogin;
 class GitHubRepoFullNameTest extends \PHPUnit_Framework_TestCase
 {
     /** @dataProvider provideRepositoryNames */
-    public function testItExposesValue(GitHubUserLogin $owner, GitHubRepoName $repoName, string $fullName)
+    public function testItExposesValue(GitHubAccountLogin $owner, GitHubRepoName $repoName, string $fullName)
     {
         $sut = new GitHubRepoFullName($owner, $repoName);
         $this->assertEquals($fullName, $sut->getValue());
     }
 
     /** @dataProvider provideRepositoryNames */
-    public function testItCanBeAutoConvertedToString(GitHubUserLogin $owner, GitHubRepoName $repoName, string $fullName)
+    public function testItCanBeAutoConvertedToString(GitHubAccountLogin $owner, GitHubRepoName $repoName, string $fullName)
     {
         $sut = new GitHubRepoFullName($owner, $repoName);
         $this->assertEquals($fullName, (string) $sut);
     }
 
     /** @dataProvider provideRepositoryNames */
-    public function testOwnerIsExposedViaGetter(GitHubUserLogin $owner, GitHubRepoName $repoName)
+    public function testOwnerIsExposedViaGetter(GitHubAccountLogin $owner, GitHubRepoName $repoName)
     {
         $sut = new GitHubRepoFullName($owner, $repoName);
         $this->assertEquals($owner, $sut->getOwner());
     }
 
     /** @dataProvider provideRepositoryNames */
-    public function testRepoNameIsExposedViaGetter(GitHubUserLogin $owner, GitHubRepoName $repoName)
+    public function testRepoNameIsExposedViaGetter(GitHubAccountLogin $owner, GitHubRepoName $repoName)
     {
         $sut = new GitHubRepoFullName($owner, $repoName);
         $this->assertEquals($repoName, $sut->getRepoName());
     }
 
     /** @dataProvider provideRepositoryNames */
-    public function testItCanBeCreatedFromFullName(GitHubUserLogin $owner, GitHubRepoName $repoName, string $fullName)
+    public function testItCanBeCreatedFromFullName(GitHubAccountLogin $owner, GitHubRepoName $repoName, string $fullName)
     {
         $sut = GitHubRepoFullName::createFromString($fullName);
         $this->assertEquals($fullName, $sut->getValue());
@@ -54,7 +54,7 @@ class GitHubRepoFullNameTest extends \PHPUnit_Framework_TestCase
     public function provideRepositoryNames()
     {
         return [
-            [new GitHubUserLogin('devboard-test'), new GitHubRepoName('super-library'), 'devboard-test/super-library'],
+            [new GitHubAccountLogin('devboard-test'), new GitHubRepoName('super-library'), 'devboard-test/super-library'],
         ];
     }
 }

--- a/tests/Repo/GitHubRepoOwnerTest.php
+++ b/tests/Repo/GitHubRepoOwnerTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace tests\Devboard\GitHub\Repo;
 
+use Devboard\GitHub\Account\GitHubAccountApiUrl;
+use Devboard\GitHub\Account\GitHubAccountAvatarUrl;
+use Devboard\GitHub\Account\GitHubAccountGravatarId;
+use Devboard\GitHub\Account\GitHubAccountHtmlUrl;
+use Devboard\GitHub\Account\GitHubAccountId;
+use Devboard\GitHub\Account\GitHubAccountLogin;
 use Devboard\GitHub\Account\GitHubAccountType;
 use Devboard\GitHub\Account\Type\Organization;
 use Devboard\GitHub\Account\Type\User;
 use Devboard\GitHub\Repo\GitHubRepoOwner;
-use Devboard\GitHub\User\GitHubUserApiUrl;
-use Devboard\GitHub\User\GitHubUserAvatarUrl;
-use Devboard\GitHub\User\GitHubUserGravatarId;
-use Devboard\GitHub\User\GitHubUserHtmlUrl;
-use Devboard\GitHub\User\GitHubUserId;
-use Devboard\GitHub\User\GitHubUserLogin;
 
 /**
  * @covers \Devboard\GitHub\Repo\GitHubRepoOwner
@@ -23,13 +23,13 @@ class GitHubRepoOwnerTest extends \PHPUnit_Framework_TestCase
 {
     /** @dataProvider provideArguments */
     public function testCreating(
-        GitHubUserId $userId,
-        GitHubUserLogin $login,
+        GitHubAccountId $userId,
+        GitHubAccountLogin $login,
         GitHubAccountType $gitHubAccountType,
-        GitHubUserAvatarUrl $avatarUrl,
-        GitHubUserGravatarId $gravatarId,
-        GitHubUserHtmlUrl $htmlUrl,
-        GitHubUserApiUrl $apiUrl,
+        GitHubAccountAvatarUrl $avatarUrl,
+        GitHubAccountGravatarId $gravatarId,
+        GitHubAccountHtmlUrl $htmlUrl,
+        GitHubAccountApiUrl $apiUrl,
         bool $siteAdmin
     ) {
         $sut = new GitHubRepoOwner(
@@ -48,13 +48,13 @@ class GitHubRepoOwnerTest extends \PHPUnit_Framework_TestCase
 
     /** @dataProvider provideArguments */
     public function testSerializationAndDeserialization(
-        GitHubUserId $userId,
-        GitHubUserLogin $login,
+        GitHubAccountId $userId,
+        GitHubAccountLogin $login,
         GitHubAccountType $gitHubAccountType,
-        GitHubUserAvatarUrl $avatarUrl,
-        GitHubUserGravatarId $gravatarId,
-        GitHubUserHtmlUrl $htmlUrl,
-        GitHubUserApiUrl $apiUrl,
+        GitHubAccountAvatarUrl $avatarUrl,
+        GitHubAccountGravatarId $gravatarId,
+        GitHubAccountHtmlUrl $htmlUrl,
+        GitHubAccountApiUrl $apiUrl,
         bool $siteAdmin
     ) {
         $sut = new GitHubRepoOwner(
@@ -70,33 +70,33 @@ class GitHubRepoOwnerTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [
-                new GitHubUserId(13507412),
-                new GitHubUserLogin('devboard-test'),
+                new GitHubAccountId(13507412),
+                new GitHubAccountLogin('devboard-test'),
                 new User(),
-                new GitHubUserAvatarUrl('https://avatars.githubusercontent.com/u/13507412?v=3'),
-                new GitHubUserGravatarId(''),
-                new GitHubUserHtmlUrl('https://github.com/devboard-test'),
-                new GitHubUserApiUrl('https://api.github.com/users/devboard-test'),
+                new GitHubAccountAvatarUrl('https://avatars.githubusercontent.com/u/13507412?v=3'),
+                new GitHubAccountGravatarId(''),
+                new GitHubAccountHtmlUrl('https://github.com/devboard-test'),
+                new GitHubAccountApiUrl('https://api.github.com/users/devboard-test'),
                 false,
             ],
             [
-                new GitHubUserId(13396338),
-                new GitHubUserLogin('devboard'),
+                new GitHubAccountId(13396338),
+                new GitHubAccountLogin('devboard'),
                 new Organization(),
-                new GitHubUserAvatarUrl('https://avatars.githubusercontent.com/u/13396338?v=3'),
-                new GitHubUserGravatarId(''),
-                new GitHubUserHtmlUrl('https://github.com/devboard'),
-                new GitHubUserApiUrl('https://api.github.com/users/devboard'),
+                new GitHubAccountAvatarUrl('https://avatars.githubusercontent.com/u/13396338?v=3'),
+                new GitHubAccountGravatarId(''),
+                new GitHubAccountHtmlUrl('https://github.com/devboard'),
+                new GitHubAccountApiUrl('https://api.github.com/users/devboard'),
                 false,
             ],
             [
-                new GitHubUserId(1),
-                new GitHubUserLogin('octocat'),
+                new GitHubAccountId(1),
+                new GitHubAccountLogin('octocat'),
                 new User(),
-                new GitHubUserAvatarUrl('https://avatars.githubusercontent.com/u/1?v=3'),
-                new GitHubUserGravatarId(''),
-                new GitHubUserHtmlUrl('https://github.com/octocat'),
-                new GitHubUserApiUrl('https://api.github.com/users/octocat'),
+                new GitHubAccountAvatarUrl('https://avatars.githubusercontent.com/u/1?v=3'),
+                new GitHubAccountGravatarId(''),
+                new GitHubAccountHtmlUrl('https://github.com/octocat'),
+                new GitHubAccountApiUrl('https://api.github.com/users/octocat'),
                 true,
             ],
         ];


### PR DESCRIPTION
On all places where reference is actually to user or organizer, switched
it to account.

Organization can own repos but cant commit for instance. This is the
difference between why using account is important.