### PR TITLE
Update composer alias: dev-master as 1.0.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4.x-dev"
+            "dev-master": "1.0.x-dev"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "80cd70eaf7eff336831c7b067a2f21a0",
+    "content-hash": "34cbdd8d322c4558f3c62b519d5650ff",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
## Story


In order to **more easily upgrade other libraries to 1.x**
For **developers** ,
We will **alias dev-master as 1.0.x-dev**
Whereas currently **we would have to use dev-master notation in other packages**

 ## References
 
 Closes #126